### PR TITLE
Fix mobile name display and project video autoplay

### DIFF
--- a/src/components/ContentManager.tsx
+++ b/src/components/ContentManager.tsx
@@ -122,6 +122,8 @@ const Projects = () => {
                               className="w-full h-auto object-contain max-h-96 pointer-events-none"
                               muted
                               loop
+                              autoPlay
+                              playsInline
                               preload="metadata"
                             />
                             <div className="absolute inset-0 bg-black/20 opacity-0 group-hover/expand:opacity-100 transition-opacity flex items-center justify-center">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -34,7 +34,7 @@ const Header = () => {
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-2 text-primary">
             <Terminal className="h-6 w-6" />
-            <span className="text-xl font-bold">Simelwe Ngcobo</span>
+            <span className="text-lg sm:text-xl font-bold">Simelwe Ngcobo</span>
           </div>
 
           {/* Desktop Navigation */}


### PR DESCRIPTION
## Purpose
Based on user feedback, this PR addresses two mobile usability issues:
- Name text in header was too large and didn't fit properly on mobile devices
- Project videos weren't displaying/playing until manually tapped by users

## Code changes
- **Header component**: Reduced font size from `text-xl` to `text-lg` on mobile with responsive sizing (`text-lg sm:text-xl`) to improve mobile display
- **ContentManager component**: Added `autoPlay` and `playsInline` attributes to project videos to ensure they start playing automatically and display properly on mobile devices

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7ca8d86ad15045529f45ce1f0ff70642/stellar-nest)

👀 [Preview Link](https://7ca8d86ad15045529f45ce1f0ff70642-stellar-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7ca8d86ad15045529f45ce1f0ff70642</projectId>-->
<!--<branchName>stellar-nest</branchName>-->